### PR TITLE
Support external redis host and using 127.0.0.1 as default

### DIFF
--- a/platform/main.go
+++ b/platform/main.go
@@ -130,7 +130,7 @@ func doMain(ctx context.Context) error {
 
 	logger.Tf(ctx, "load .env as MGMT_PASSWORD=%vB, "+
 		"SRS_PLATFORM_SECRET=%vB, CLOUD=%v, REGION=%v, SOURCE=%v, SRT_PORT=%v, RTC_PORT=%v, "+
-		"NODE_ENV=%v, LOCAL_RELEASE=%v, REDIS_PASSWORD=%vB, REDIS_PORT=%v, RTMP_PORT=%v, "+
+		"NODE_ENV=%v, LOCAL_RELEASE=%v, REDIS_DATABASE=%v, REDIS_HOST=%v, REDIS_PASSWORD=%vB, REDIS_PORT=%v, RTMP_PORT=%v, "+
 		"PUBLIC_URL=%v, BUILD_PATH=%v, REACT_APP_LOCALE=%v, PLATFORM_LISTEN=%v, HTTP_PORT=%v, "+
 		"REGISTRY=%v, MGMT_LISTEN=%v, HTTPS_LISTEN=%v, AUTO_SELF_SIGNED_CERTIFICATE=%v, "+
 		"NAME_LOOKUP=%v, PLATFORM_DOCKER=%v, SRS_FORWARD_LIMIT=%v, SRS_VLIVE_LIMIT=%v, "+
@@ -138,7 +138,8 @@ func doMain(ctx context.Context) error {
 		len(envMgmtPassword()), len(envApiSecret()), envCloud(),
 		envRegion(), envSource(), envSrtListen(), envRtcListen(),
 		envNodeEnv(), envLocalRelease(),
-		len(envRedisPassword()), envRedisPort(), envRtmpPort(), envPublicUrl(),
+		envRedisDatabase(), envRedisHost(), len(envRedisPassword()), envRedisPort(),
+		envRtmpPort(), envPublicUrl(),
 		envBuildPath(), envReactAppLocale(), envPlatformListen(), envHttpPort(),
 		envRegistry(), envMgmtListen(), envHttpListen(),
 		envSelfSignedCertificate(), envNameLookup(),

--- a/platform/main.go
+++ b/platform/main.go
@@ -104,6 +104,8 @@ func doMain(ctx context.Context) error {
 	setEnvDefault("REACT_APP_LOCALE", "en")
 
 	// Migrate from mgmt.
+	setEnvDefault("REDIS_DATABASE", "0")
+	setEnvDefault("REDIS_HOST", "127.0.0.1")
 	setEnvDefault("REDIS_PORT", "6379")
 	setEnvDefault("MGMT_LISTEN", "2022")
 

--- a/platform/utils.go
+++ b/platform/utils.go
@@ -491,7 +491,7 @@ var rdb *redis.Client
 func InitRdb() error {
 	redisDatabase, err := strconv.Atoi(envRedisDatabase())
 	if err != nil {
-		return errors.Wrapf(err, "invalid REDIS_DATABASE")
+		return errors.Wrapf(err, "invalid REDIS_DATABASE %v", envRedisDatabase())
 	}
 
 	rdb = redis.NewClient(&redis.Options{

--- a/platform/utils.go
+++ b/platform/utils.go
@@ -436,6 +436,10 @@ func envRedisPort() string {
 	return os.Getenv("REDIS_PORT")
 }
 
+func envRedisAddress() string {
+	return os.Getenv("REDIS_ADDRESS")
+}
+
 func envRtmpPort() string {
 	return os.Getenv("RTMP_PORT")
 }
@@ -481,7 +485,11 @@ var rdb *redis.Client
 
 // InitRdb create and init global rdb, which is a redis client.
 func InitRdb() error {
-	addr := "127.0.0.1"
+	addr := envRedisAddress()
+	if addr == "" {
+		addr = "127.0.0.1"
+	}
+
 	rdb = redis.NewClient(&redis.Options{
 		Addr:     fmt.Sprintf("%v:%v", addr, envRedisPort()),
 		Password: envRedisPassword(),

--- a/platform/utils.go
+++ b/platform/utils.go
@@ -436,8 +436,12 @@ func envRedisPort() string {
 	return os.Getenv("REDIS_PORT")
 }
 
-func envRedisAddress() string {
-	return os.Getenv("REDIS_ADDRESS")
+func envRedisHost() string {
+	return os.Getenv("REDIS_HOST")
+}
+
+func envRedisDatabase() string {
+	return os.Getenv("REDIS_DATABASE")
 }
 
 func envRtmpPort() string {
@@ -485,15 +489,15 @@ var rdb *redis.Client
 
 // InitRdb create and init global rdb, which is a redis client.
 func InitRdb() error {
-	addr := envRedisAddress()
-	if addr == "" {
-		addr = "127.0.0.1"
+	redisDatabase, err := strconv.Atoi(envRedisDatabase())
+	if err != nil {
+		return errors.Wrapf(err, "invalid REDIS_DATABASE")
 	}
 
 	rdb = redis.NewClient(&redis.Options{
-		Addr:     fmt.Sprintf("%v:%v", addr, envRedisPort()),
+		Addr:     fmt.Sprintf("%v:%v", envRedisHost(), envRedisPort()),
 		Password: envRedisPassword(),
-		DB:       0,
+		DB:       redisDatabase,
 	})
 	return nil
 }


### PR DESCRIPTION
I want to use my external redis because after many hours of streaming and recording oryx stops working. There are many keys written that get cleaned only after you delete the recording task.
I would like to be able to use my custom redis to support more intensive recordings