### PR TITLE
Port 1985 listening issue in docker containers

### DIFF
--- a/platform/containers/conf/srs.release.conf
+++ b/platform/containers/conf/srs.release.conf
@@ -12,7 +12,7 @@ daemon              on;
 disable_daemon_for_docker off;
 http_api {
     enabled         on;
-    listen          127.0.0.1:1985;
+    listen          1985;
     raw_api {
         enabled on;
         allow_reload on;


### PR DESCRIPTION
Remove the IP restriction on port 1985. Under certain network conditions, the address 127.0.0.1:1985 cannot be properly mapped to external requests within a Docker container. For a similar issue, refer to: https://github.com/ossrs/oryx/discussions/202.

---------

`TRANS_BY_GPT4`