### PR TITLE
replace action runner from ubuntu-20.04 -> ubuntu-22.04

### DIFF
--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -12,7 +12,7 @@ jobs:
       ##################################################################################################################
       # Git checkout
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # The github.ref is, for example, refs/tags/v5.0.145 or refs/tags/v5.0-r8
       # Generate variables like:
       #   SRS_TAG=nodejs-v1.0.52
@@ -40,7 +40,7 @@ jobs:
           echo "SRS_MAJOR=${{ needs.envs.outputs.SRS_MAJOR }}" >> $GITHUB_ENV
       # Git checkout
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Build SRS image
       - name: Build SRS docker image
         run: |
@@ -94,7 +94,7 @@ jobs:
           echo "SRS_MAJOR=${{ needs.envs.outputs.SRS_MAJOR }}" >> $GITHUB_ENV
       # Git checkout
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # Generate variables like:
       #   SRS_DROPLET_EIP=1.2.3.4
       - name: Build droplet variables

--- a/.github/workflows/api-release.yml
+++ b/.github/workflows/api-release.yml
@@ -28,7 +28,7 @@ jobs:
     outputs:
       SRS_TAG: ${{ env.SRS_TAG }}
       SRS_MAJOR: ${{ env.SRS_MAJOR }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   docker:
     needs:
@@ -56,7 +56,7 @@ jobs:
         run: |
           docker tag ossrs/oryx:$SRS_TAG ossrs/oryx:$SRS_MAJOR
           docker push --all-tags ossrs/oryx
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   aliyun:
     needs:
@@ -81,7 +81,7 @@ jobs:
           dst: |
             registry.cn-hangzhou.aliyuncs.com/ossrs/oryx:${{ env.SRS_TAG }}
             registry.cn-hangzhou.aliyuncs.com/ossrs/oryx:${{ env.SRS_MAJOR }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   deploy:
     needs:
@@ -137,4 +137,4 @@ jobs:
               docker rmi -f $image
               echo "Remove image $image, r0=$?"
             done
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -46,7 +46,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v4
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/focal.yml
+++ b/.github/workflows/focal.yml
@@ -12,7 +12,7 @@ jobs:
       ##################################################################################################################
       # Git checkout
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # The github.ref is, for example, refs/tags/v5.0.145 or refs/tags/v5.0-r8
       # Generate variables like:
       #   SRS_TAG=nodejs-v1.0.52
@@ -40,7 +40,7 @@ jobs:
           echo "SRS_MAJOR=${{ needs.envs.outputs.SRS_MAJOR }}" >> $GITHUB_ENV
       # Git checkout
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # See https://github.com/crazy-max/ghaction-docker-buildx#moved-to-docker-organization
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU

--- a/.github/workflows/focal.yml
+++ b/.github/workflows/focal.yml
@@ -28,7 +28,7 @@ jobs:
     outputs:
       SRS_TAG: ${{ env.SRS_TAG }}
       SRS_MAJOR: ${{ env.SRS_MAJOR }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   docker:
     needs:
@@ -66,7 +66,7 @@ jobs:
           src: ossrs/oryx:${{ env.SRS_TAG }}
           dst: |
             ossrs/oryx:${{ env.SRS_MAJOR }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   aliyun:
     needs:
@@ -91,4 +91,4 @@ jobs:
           dst: |
             registry.cn-hangzhou.aliyuncs.com/ossrs/oryx:${{ env.SRS_TAG }}
             registry.cn-hangzhou.aliyuncs.com/ossrs/oryx:${{ env.SRS_MAJOR }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04

--- a/.github/workflows/mirrors.yml
+++ b/.github/workflows/mirrors.yml
@@ -77,7 +77,7 @@ jobs:
           dst: |
             ossrs/ubuntu:focal
             ossrs/ubuntu
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   # See https://cr.console.aliyun.com/repository/cn-hangzhou/ossrs/node/images
   aliyun-node:
@@ -97,7 +97,7 @@ jobs:
             registry.cn-hangzhou.aliyuncs.com/ossrs/node:slim
             registry.cn-hangzhou.aliyuncs.com/ossrs/node:hydrogen-slim
             registry.cn-hangzhou.aliyuncs.com/ossrs/node:18
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   # See https://cr.console.aliyun.com/repository/cn-hangzhou/ossrs/prometheus/images
   aliyun-prom:
@@ -116,7 +116,7 @@ jobs:
           dst: |
             registry.cn-hangzhou.aliyuncs.com/ossrs/prometheus:v2.40.7
             registry.cn-hangzhou.aliyuncs.com/ossrs/prometheus
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   # See https://cr.console.aliyun.com/repository/cn-hangzhou/ossrs/pushgateway/images
   aliyun-pushgateway:
@@ -135,7 +135,7 @@ jobs:
           dst: |
             registry.cn-hangzhou.aliyuncs.com/ossrs/pushgateway:v1.4.3
             registry.cn-hangzhou.aliyuncs.com/ossrs/pushgateway
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   # See https://cr.console.aliyun.com/repository/cn-hangzhou/ossrs/redis_exporter/images
   aliyun-redis-exporter:
@@ -153,7 +153,7 @@ jobs:
           src: oliver006/redis_exporter
           dst: |
             registry.cn-hangzhou.aliyuncs.com/ossrs/redis_exporter
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   # See https://cr.console.aliyun.com/repository/cn-hangzhou/ossrs/node-exporter/images
   aliyun-node-exporter:
@@ -172,7 +172,7 @@ jobs:
           dst: |
             registry.cn-hangzhou.aliyuncs.com/ossrs/node-exporter
             registry.cn-hangzhou.aliyuncs.com/ossrs/node-exporter:v1.4.1
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   # See https://cr.console.aliyun.com/repository/cn-hangzhou/ossrs/redis/images
   # TODO: FIXME: Only amd64.
@@ -192,7 +192,7 @@ jobs:
           dst: |
             registry.cn-hangzhou.aliyuncs.com/ossrs/redis:5.0
             registry.cn-hangzhou.aliyuncs.com/ossrs/redis
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   # See https://cr.console.aliyun.com/repository/cn-hangzhou/ossrs/grafana/images
   aliyun-grafana:
@@ -211,7 +211,7 @@ jobs:
           dst: |
             registry.cn-hangzhou.aliyuncs.com/ossrs/grafana:9.3.1
             registry.cn-hangzhou.aliyuncs.com/ossrs/grafana
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   # See https://cr.console.aliyun.com/repository/cn-hangzhou/ossrs/ubuntu/images
   aliyun-ubuntu:
@@ -230,5 +230,5 @@ jobs:
           dst: |
             registry.cn-hangzhou.aliyuncs.com/ossrs/ubuntu:focal
             registry.cn-hangzhou.aliyuncs.com/ossrs/ubuntu
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 

--- a/.github/workflows/nginx-hls-cdn.yml
+++ b/.github/workflows/nginx-hls-cdn.yml
@@ -19,7 +19,7 @@ jobs:
       SRS_VERSION: ${{ env.SRS_VERSION }}
       SRS_MAJOR_HTTP: ${{ env.SRS_MAJOR_HTTP }}
       SRS_MAJOR_HTTPS: ${{ env.SRS_MAJOR_HTTPS }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   docker:
     needs:
@@ -71,7 +71,7 @@ jobs:
           src: ossrs/oryx:${{ env.SRS_MAJOR_HTTPS }}
           dst: |
             ossrs/oryx:${{ env.SRS_MAJOR_HTTPS }}-${{ env.SRS_VERSION }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   aliyun:
     needs:
@@ -105,4 +105,4 @@ jobs:
           dst: |
             registry.cn-hangzhou.aliyuncs.com/ossrs/oryx:${{ env.SRS_MAJOR_HTTPS }}
             registry.cn-hangzhou.aliyuncs.com/ossrs/oryx:${{ env.SRS_MAJOR_HTTPS }}-${{ env.SRS_VERSION }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04

--- a/.github/workflows/nginx-hls-cdn.yml
+++ b/.github/workflows/nginx-hls-cdn.yml
@@ -31,7 +31,7 @@ jobs:
           echo "SRS_MAJOR_HTTP=${{ needs.envs.outputs.SRS_MAJOR_HTTP }}" >> $GITHUB_ENV
           echo "SRS_MAJOR_HTTPS=${{ needs.envs.outputs.SRS_MAJOR_HTTPS }}" >> $GITHUB_ENV
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v2
       - name: Set up Docker Buildx

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -14,7 +14,7 @@ jobs:
       ##################################################################################################################
       # Git checkout
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # The github.ref is, for example, refs/tags/v5.0.145 or refs/tags/v5.0-r8
       # Generate variables like:
       #   SRS_TAG=v1.0.52
@@ -40,7 +40,7 @@ jobs:
       - envs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download test file
         run: |
           curl --location --output test/source.200kbps.768x320.flv \
@@ -72,13 +72,13 @@ jobs:
       - envs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build image for platform
         run: |
           docker build -t platform:latest -f Dockerfile .
           docker images
           docker save -o platform.tar platform:latest
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: platform-cache
           path: platform.tar
@@ -91,7 +91,7 @@ jobs:
       - build-platform-image
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download test file
         run: |
           curl --location --output test/source.200kbps.768x320.flv \
@@ -101,7 +101,7 @@ jobs:
           docker run --rm -v /usr/bin:/g ossrs/srs:tools \
             cp /usr/local/bin/ffmpeg /usr/local/bin/ffprobe /g/
           ffmpeg -version
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: platform-cache
       - name: Run test for platform image
@@ -163,7 +163,7 @@ jobs:
       - build-platform-image
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download test file
         run: |
           curl --location --output test/source.200kbps.768x320.flv \
@@ -173,7 +173,7 @@ jobs:
           docker run --rm -v /usr/bin:/g ossrs/srs:tools \
             cp /usr/local/bin/ffmpeg /usr/local/bin/ffprobe /g/
           ffmpeg -version
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: platform-cache
       - name: Run test for platform image
@@ -240,7 +240,7 @@ jobs:
           echo "SRS_TAG=${{ needs.envs.outputs.SRS_TAG }}" >> $GITHUB_ENV
           echo "SRS_MAJOR=${{ needs.envs.outputs.SRS_MAJOR }}" >> $GITHUB_ENV
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download test file
         run: |
           curl --location --output test/source.200kbps.768x320.flv \
@@ -254,7 +254,7 @@ jobs:
         run: |
           sudo systemctl start nginx
           sudo systemctl status nginx
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: platform-cache
       - name: Load platform image
@@ -329,7 +329,7 @@ jobs:
           echo "SRS_TAG=${{ needs.envs.outputs.SRS_TAG }}" >> $GITHUB_ENV
           echo "SRS_MAJOR=${{ needs.envs.outputs.SRS_MAJOR }}" >> $GITHUB_ENV
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download test file
         run: |
           curl --location --output test/source.200kbps.768x320.flv \
@@ -343,7 +343,7 @@ jobs:
         run: |
           sudo systemctl start nginx
           sudo systemctl status nginx
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: platform-cache
       - name: Load platform image

--- a/.github/workflows/pullrequest.yml
+++ b/.github/workflows/pullrequest.yml
@@ -31,11 +31,11 @@ jobs:
     outputs:
       SRS_TAG: ${{ env.SRS_TAG }}
       SRS_MAJOR: ${{ env.SRS_MAJOR }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   run-test:
     name: Run UTest
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - envs
     steps:
@@ -67,7 +67,7 @@ jobs:
 
   build-platform-image:
     name: Build platform image
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - envs
     steps:
@@ -154,7 +154,7 @@ jobs:
           echo "Log of docker.log" && cat docker.log
           
           exit $ret
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   test-en-image:
     name: Test EN image
@@ -226,11 +226,11 @@ jobs:
           echo "Log of docker.log" && cat docker.log
           
           exit $ret
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   test-zh-installer:
     name: Test ZH installer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - envs
       - build-platform-image
@@ -319,7 +319,7 @@ jobs:
 
   test-en-installer:
     name: Test EN installer
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - envs
       - build-platform-image
@@ -408,7 +408,7 @@ jobs:
 
   test-pr-final:
     name: test-pr-final
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - run-test
       - test-zh-image

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,7 +21,7 @@ jobs:
         if: steps.wait-for-test.outputs.conclusion != 'success'
         run: |
           echo "Test Workflow failed, aborting release" && exit 1
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   check-test-online:
     steps:
@@ -37,7 +37,7 @@ jobs:
         if: steps.wait-for-test.outputs.conclusion != 'success'
         run: |
           echo "Test Workflow failed, aborting release" && exit 1
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   envs:
     needs:
@@ -68,7 +68,7 @@ jobs:
       SRS_TAG: ${{ env.SRS_TAG }}
       SRS_MAJOR: ${{ env.SRS_MAJOR }}
       SRS_XYZ: ${{ env.SRS_XYZ }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   docker:
     needs:
@@ -114,7 +114,7 @@ jobs:
         # TODO: FIXME: If stable release, update it.
         #ossrs/oryx:${{ env.SRS_MAJOR }}
         #ossrs/oryx:v${{ env.SRS_MAJOR }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   aliyun:
     needs:
@@ -143,7 +143,7 @@ jobs:
         # TODO: FIXME: If stable release, update it.
         #registry.cn-hangzhou.aliyuncs.com/ossrs/oryx:${{ env.SRS_MAJOR }}
         #registry.cn-hangzhou.aliyuncs.com/ossrs/oryx:v${{ env.SRS_MAJOR }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   draft:
     name: draft
@@ -165,11 +165,11 @@ jobs:
     # Map a step output to a job output, see https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
     outputs:
       SRS_RELEASE_ID: ${{ steps.create_draft.outputs.id }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   plugin:
     name: release-publication
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - draft
       - envs

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
     steps:
       # Git checkout
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # The github.ref is, for example, refs/tags/v5.0.145 or refs/tags/v5.0-r8
       # Generate variables like:
       #   SRS_TAG=v5.8.20
@@ -81,7 +81,7 @@ jobs:
           echo "SRS_XYZ=${{ needs.envs.outputs.SRS_XYZ }}" >> $GITHUB_ENV
       # Git checkout
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # See https://github.com/crazy-max/ghaction-docker-buildx#moved-to-docker-organization
       # https://github.com/docker/setup-qemu-action
       - name: Set up QEMU
@@ -176,7 +176,7 @@ jobs:
     steps:
       ##################################################################################################################
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       ##################################################################################################################
       - name: Covert output to env
         run: |

--- a/.github/workflows/test-online.yml
+++ b/.github/workflows/test-online.yml
@@ -14,7 +14,7 @@ jobs:
       ##################################################################################################################
       # Git checkout
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # The github.ref is, for example, refs/tags/v5.0.145 or refs/tags/v5.0-r8
       # Generate variables like:
       #   SRS_TAG=v1.0.52
@@ -42,13 +42,13 @@ jobs:
       - envs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build image for platform
         run: |
           docker build -t platform:latest -f Dockerfile .
           docker images
           docker save -o platform.tar platform:latest
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: platform-cache
           path: platform.tar
@@ -103,7 +103,7 @@ jobs:
           echo "Never dispose:"
           echo "  for((;;)); do ssh root@$SRS_DROPLET_EIP touch ctrl-debugging ctrl-reset; sleep 3; done"
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Download test file
         run: |
           curl --location --output test/source.200kbps.768x320.flv \
@@ -203,8 +203,8 @@ jobs:
         with:
           token: ${{ secrets.DIGITALOCEAN_ACCESS_TOKEN }}
       - name: Checkout repository
-        uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+        uses: actions/checkout@v4
+      - uses: actions/download-artifact@v4
         with:
           name: platform-cache
       - name: Setup the Go

--- a/.github/workflows/test-online.yml
+++ b/.github/workflows/test-online.yml
@@ -34,7 +34,7 @@ jobs:
       SRS_TAG: ${{ env.SRS_TAG }}
       SRS_MAJOR: ${{ env.SRS_MAJOR }}
       SRS_DOMAIN: ${{ env.SRS_DOMAIN }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   build-image:
     name: Build Image
@@ -53,7 +53,7 @@ jobs:
           name: platform-cache
           path: platform.tar
           retention-days: 1
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   create-vm-domain:
     name: Create VM Domain
@@ -175,7 +175,7 @@ jobs:
     # Map a step output to a job output, see https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
     outputs:
       SRS_DROPLET_EIP: ${{ env.SRS_DROPLET_EIP }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   run-test:
     name: Run Test
@@ -352,7 +352,7 @@ jobs:
     # Map a step output to a job output, see https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
     outputs:
       SRS_DROPLET_EIP: ${{ env.SRS_DROPLET_EIP }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   dispose-waiting:
     name: Dispose Waiting
@@ -416,7 +416,7 @@ jobs:
     # Map a step output to a job output, see https://docs.github.com/en/actions/using-jobs/defining-outputs-for-jobs
     outputs:
       SRS_DROPLET_EIP: ${{ env.SRS_DROPLET_EIP }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   dispose-final:
     name: Dispose Final
@@ -453,7 +453,7 @@ jobs:
             doctl compute domain records delete ossrs.io $DOMAIN_ID -f
           fi
       - run: echo OK
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   # Final test result, fail if any jobs failed.
   test-online-final:
@@ -464,4 +464,4 @@ jobs:
       - dispose-final
     steps:
       - run: echo OK
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -30,7 +30,7 @@ jobs:
     outputs:
       SRS_TAG: ${{ env.SRS_TAG }}
       SRS_MAJOR: ${{ env.SRS_MAJOR }}
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   test-en-image:
     name: Test EN image
@@ -103,7 +103,7 @@ jobs:
           echo "Log of docker.log" && cat docker.log
           
           exit $ret
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   check-pr-test:
     steps:
@@ -119,11 +119,11 @@ jobs:
         if: steps.wait-for-test.outputs.conclusion != 'success'
         run: |
           echo "Test Workflow failed, aborting release" && exit 1
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 
   test-final:
     name: test-final
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     needs:
       - check-pr-test
       - test-en-image

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       ##################################################################################################################
       # Git checkout
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       # The github.ref is, for example, refs/tags/v5.0.145 or refs/tags/v5.0-r8
       # Generate variables like:
       #   SRS_TAG=v1.0.52
@@ -38,7 +38,7 @@ jobs:
       - envs
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Build image for platform
         run: |
           docker build -t platform:latest -f Dockerfile .


### PR DESCRIPTION
# Background

Ubuntu 20.04 LTS runner was be removed on 2025-04-15.
@see https://github.com/actions/runner-images/issues/11101

github actions are configured to run in ubuntu-20.04, which was be removed by github, so has to upgrade it.